### PR TITLE
feat: パッケージを提供

### DIFF
--- a/__envit__/command.sh
+++ b/__envit__/command.sh
@@ -28,6 +28,7 @@ EndRunAnyOne() {
   if [ ! -z "$_envit_command_last_command" ]; then
     cat $_envit_command_last_command_output
     echo "failed execute: $*"
+    rm $_envit_command_last_command_output
     exit 1
   fi
 

--- a/__envit__/download.sh
+++ b/__envit__/download.sh
@@ -1,0 +1,13 @@
+DownloadFile() {
+  url=$1
+  out=$2
+
+  if command -v curl > /dev/null; then
+    curl -L -o $out $url
+  elif command -v wget > /dev/null; then
+    wget -O $out $url
+  else
+    echo curl or wget is not installed.
+    exit 1
+  fi
+}

--- a/__envit__/import.sh
+++ b/__envit__/import.sh
@@ -13,7 +13,7 @@ ImportPackageFromDirectory() {(
     BuildPackageFromDirectory $source_root
   fi
 
-  CopyDirectory $store_root $profile_root
+  CopyDirectory "$EnvitRoot/store/$hash" $profile_root
 )}
 
 ImportPackageFromGithub() {(

--- a/__envit__/package.sh
+++ b/__envit__/package.sh
@@ -1,6 +1,7 @@
 InitPackageDSL() {
   . $_ModuleExecRoot/__envit__/build.sh
   . $_ModuleExecRoot/__envit__/import.sh
+  . $_ModuleExecRoot/__envit__/download.sh
 
   Name() {
     package_name=$1

--- a/pkgs/nodejs_21/package.envit.sh
+++ b/pkgs/nodejs_21/package.envit.sh
@@ -1,0 +1,62 @@
+Name "nodejs"
+Version "21.5.0"
+Description "nodejs v21 package for envit"
+
+Inputs() { return; }
+
+Build() {
+  case $(uname -s | tr [:upper:] [:lower:]) in
+    "linux")
+      os=linux
+      break
+      ;;
+
+    "darwin")
+      os=darwin
+      break
+      ;;
+
+    *)
+      echo unspported platform
+      exit 1
+      break
+      ;;
+  esac
+
+  case $(uname -m | tr [:upper:] [:lower:]) in
+    "x86_64" | "amd64")
+      arch=x64
+      break
+      ;;
+
+    "arm64")
+      arch=arm64
+      break
+      ;;
+
+    "armv7l")
+      arch=armv7l
+      break
+      ;;
+
+    "i386" | "x86")
+      arch=x86
+      break
+      ;;
+
+    *)
+      echo unspported architecture
+      exit 1
+      break
+      ;;
+  esac
+
+  DownloadFile https://nodejs.org/dist/v$package_version/node-v$package_version-$os-$arch.tar.gz node-v$package_version-$os-$arch.tar.gz
+  tar -zxvf node-v$package_version-$os-$arch.tar.gz --strip-component 1 node-v$package_version-$os-$arch/bin node-v$package_version-$os-$arch/lib node-v$package_version-$os-$arch/share
+}
+
+Outputs() {
+  Output bin
+  Output lib
+  Output share
+}

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,9 @@ $ envit build github:hoge/fuga@v0.1.0
 For use in environments requiring high availability, it is recommended to use other tools such as nix, docker, podman, etc.
 
 # dependencies
-- git (optional)
 - sh
+- git (optional)
+- curl or wget (optional)
 
 # Installation
 

--- a/scripts/install-envit.sh
+++ b/scripts/install-envit.sh
@@ -43,7 +43,7 @@ EOS
         BEGIN {
           b=1
         }
-  
+
         /# begin envit configuration/ {
           b=0
         }


### PR DESCRIPTION
試験的にnodejs v21のみ出してみる

パッケージのビルド時用に `DownloadFile <url> <outfile>` というヘルパーを追加

これは、curlまたはwgetがインストールされていればwebからファイルをダウンロードできるもの

パッケージにはenvitにhttp通信機能が埋め込まれた時に移行しなくても良いようにヘルパーを使うことを推奨する